### PR TITLE
Update FCGI handler docs to use daemonize not detach

### DIFF
--- a/lib/Plack/Handler/FCGI.pm
+++ b/lib/Plack/Handler/FCGI.pm
@@ -231,9 +231,9 @@ Plack::Handler::FCGI - FastCGI handler for Plack
 
   # Roll your own
   my $server = Plack::Handler::FCGI->new(
-      nproc  => $num_proc,
-      listen => [ $port_or_socket ],
-      detach => 1,
+      nproc     => $num_proc,
+      listen    => [ $port_or_socket ],
+      daemonize => 1,
   );
   $server->run($app);
 


### PR DESCRIPTION
Since detach is not documented as an option, it was confusing to me until I read the source and saw that it was the old name for daemonize.
